### PR TITLE
(optional) ultracdc.go: Cutpoints() function computes batches of cuts.

### DIFF
--- a/chunkers/ultracdc/ultracdc.go
+++ b/chunkers/ultracdc/ultracdc.go
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Jason E. Aten, Ph.D.
  * Copyright (c) 2023 Gilles Chehade <gilles@poolp.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -25,6 +26,8 @@ import (
 	chunkers "github.com/PlakarKorp/go-cdc-chunkers"
 )
 
+var _ = fmt.Printf
+
 func init() {
 	chunkers.Register("ultracdc", newUltraCDC)
 }
@@ -34,6 +37,16 @@ var ErrMinSize = errors.New("MinSize is required and must be 64B <= MinSize <= 1
 var ErrMaxSize = errors.New("MaxSize is required and must be 64B <= MaxSize <= 1GB && MaxSize > NormalSize")
 
 type UltraCDC struct {
+	Opts *chunkers.ChunkerOpts
+}
+
+// NewUltraCDC is for non-Plakar standalone clients. Plakar
+// clients will use newUltraCDC via the
+// chunkers.NewChunker("ultracdc", ...) factory.
+func NewUltraCDC() *UltraCDC {
+	u := &UltraCDC{}
+	u.Opts = u.DefaultOptions()
+	return u
 }
 
 func newUltraCDC() chunkers.ChunkerImplementation {
@@ -200,4 +213,187 @@ func (c *UltraCDC) Algorithm(options *chunkers.ChunkerOpts, data []byte, n int) 
 	// obviously preserves the POST INVARIANT that cutpoint <= n.
 	cutpoint = n
 	return
+}
+
+// Cutpoints computes all the cutpoints we can in a batch, all at once,
+// if maxPoints <= 0; otherwise only up to a maximum of maxPoints.
+// We may find fewer, of course. There will always be one, as
+// len(data) is returned in cuts if no sooner cutpoint is found.
+// If maxPoints <= 0 then the last cutpoint in cuts will
+// always be len(data).
+func (c *UltraCDC) Cutpoints(data []byte, maxPoints int) (cuts []int) {
+
+	const (
+		maskS uint64 = 0x2F // binary 101111
+
+		// maskL ignores 2 more bits than maskS, so
+		// it is easier to match (so we get a higher
+		// probability of match after the normal point).
+		maskL uint64 = 0x2C // binary 101100
+
+		lowEntropyStringThreshold int = 64 // LEST in the paper.
+	)
+	minSize := c.Opts.MinSize
+	maxSize := c.Opts.MaxSize
+	normalSize := c.Opts.NormalSize
+
+	if minSize <= 0 {
+		panic("MinSize must be positive")
+	}
+
+	// most recently found cut.
+	var cutpoint int
+
+	// Find as many cutpoints as we can.
+	// After each one, start again at begin.
+begin:
+	for {
+		n := len(data)
+
+		// We modify normal below, if end <= normalSize.
+		// I doubt we can would normally do another loop
+		// after that, but I cannot prove it would never
+		// happen. So to be on the safe side, we just reset it
+		// every time.
+		normal := normalSize
+
+		var lowEntropyCount int
+
+		// initial mask for small cuts below the Normal point.
+		mask := maskS
+
+		//fmt.Printf("n = %v; minSize=%v; normalSize=%v; maxSize=%v; len(cuts)=%v\n",
+		//	n, minSize, normalSize, maxSize, len(cuts))
+
+		// how far we go on a single pass through
+		// this loop looking for a cutpoint.
+		end := maxSize
+		if n < end {
+			end = n
+		}
+		if end <= minSize {
+			// clients should recognize that the very
+			// last cut may be "pre-mature".
+			cutpoint += end
+			cuts = append(cuts, cutpoint)
+			//fmt.Printf("end %v <= minSize = %v, returning\n", end, minSize)
+			return
+		}
+		//fmt.Printf("end %v > minSize = %v, not returning\n", end, minSize)
+
+		if end <= normalSize {
+			normal = end
+		}
+
+		outBufWin := data[minSize : minSize+8]
+
+		// Initialize hamming distance on outBufWin
+		dist := 0
+		for _, v := range outBufWin {
+			// effectively the Pattern of 0xAAAAAAAAAAAAAAAA,
+			// as referenced in the paper,
+			// is expressed here, just one byte at a time.
+			dist += bits.OnesCount8(v ^ 0xAA)
+		}
+
+		var inBufWin []byte
+
+	innerLoop:
+		for i := minSize + 8; i <= end-8; i += 8 {
+			if i >= normal {
+				// Yes, we write mask every time after the Normal point,
+				// and at first this appears wasteful. However,
+				// an engineering judgement call was made to keep it.
+				//
+				// The rationale is that this small redudancy
+				// is cheaper, simpler, and safer
+				// than duplicating all the logic below for the two different
+				// masks and then having to be sure to keep
+				// the duplicates in sync. We saw multiple bugs in the past from
+				// MinSize and NormalSize not being 8 byte aligned,
+				// and we'd also rather not impose that on users.
+				// The POST invariance analysis is also much simplified.
+				// The CPU has to do less branch prediction this way,
+				// and maskL will almost surely be quickly
+				// accessible in a cache line.
+				mask = maskL
+			}
+
+			// If i == n-8 then i+8 == n, and since n <= len(data)
+			// as a PRE condition, we never go out of bounds.
+			inBufWin = data[i : i+8]
+
+			if bytes.Equal(inBufWin, outBufWin) {
+				lowEntropyCount++
+				if lowEntropyCount >= lowEntropyStringThreshold {
+					// on random (high-entropy) data, we don't expect to get here.
+
+					// If i == n-8, its largest, then this returns n,
+					// which maintains our POST INVARIANT that cutpoint <= n.
+					cut := i + 8
+					cutpoint += cut
+					cuts = append(cuts, cutpoint)
+					data = data[cut:]
+					//fmt.Printf("found LEST cutpoint %v; data now len %v\n", cutpoint, len(data))
+					if len(data) == 0 || (maxPoints > 0 && len(cuts) >= maxPoints) {
+						return
+					}
+					continue begin
+				}
+				continue innerLoop
+			}
+
+			lowEntropyCount = 0
+			for j := 0; j < 8; j++ {
+				if (uint64(dist) & mask) == 0 {
+					// Do we preserve the POST INVARIANT here?
+					// if i == n-8 (the biggest possible), and
+					// j is 7 (its biggest possible), then
+					// i + j could here be as big as n - 8 + 7 == n-1
+					// So, yes, n-1 is the biggest we could return here.
+					cut := i + j
+					cutpoint += cut
+					cuts = append(cuts, cutpoint)
+					data = data[cut:]
+					//fmt.Printf("found dist cut %v; cutpoint %v; data now len %v\n", cut, cutpoint, len(data))
+					if len(data) == 0 || (maxPoints > 0 && len(cuts) >= maxPoints) {
+						return
+					}
+					continue begin
+				}
+				outByte := data[i+j-8]
+				inByte := data[i+j]
+
+				// The hamming distance instruction POPCNT is
+				// typically available in today's hardware, but
+				// upon measurement the lookup table still looks
+				// faster; plus its more portable.
+				//
+				// I'll leave the bits.OnesCountXX (POPCNT based)
+				// version here in case newer hardware gets even faster; or maybe we
+				// weren't using the hardware right when we measured.
+				// Or maybe only bits.OnesCount64 uses POPCNT? Not worth
+				// going deeper at the moment.
+				//
+				// https://stackoverflow.com/questions/28802692/how-is-popcnt-implemented-in-hardware
+				//
+				//update := bits.OnesCount8(inByte^0xAA) - bits.OnesCount8(outByte^0xAA)
+				update := hammingDistanceTo0xAA[inByte] - hammingDistanceTo0xAA[outByte]
+				dist += update
+			}
+			outBufWin = inBufWin
+
+		} // end i
+
+		cut := end
+		cutpoint += cut
+		cuts = append(cuts, cutpoint)
+		data = data[cut:]
+		//fmt.Printf("found no other cutpoint %v; data now len %v\n", cutpoint, len(data))
+		if len(data) == 0 || (maxPoints > 0 && len(cuts) >= maxPoints) {
+			return
+		}
+	}
+
+	panic("should never be reached now.")
 }


### PR DESCRIPTION
I would consider this optional for Plakar. I need it myself, 
and it may be critical for small segments between cuts, but
it doesn't fit exactly with the API that Plakar uses currently;
and the Plakar use case is naturally tuned for much bigger
segments between cutpoints.

The benchmarks (below) may be the most interesting part.

commit description:

  For smaller segment use cases, the Cutpoints()
  function in ultracdc.go computes a
  batch of cutpoints all at once.

  We Include two new benchmarks in the tests/ dir.

I draw the following conclusions from these measurements,
reproduced below.

a) UltraCDC takes about the same amount of time as just a straight
memory copy. I see this by comparing lines 12 and 13, which are
related by a ratio of 2:1. This implies that it is fairly efficient.

b) The benefit of batching is seen by comparing lines 13 and 10.
In batches (line 13), UltraCDC gets 8852 MB/sec. Making repeated,
sequential calls (line 10) gets 6432 MB/sec. Batching gives 38% better
performance in this example.

c) If you don't count the time to copy the bytes around, just
assume that part is done and the data is ready to read, then
UltraCDC can process data at 19GB/sec (line 12).


benchmarks:

~~~
$ go test -v -run=none -bench=.
goos: linux
goarch: amd64
pkg: github.com/PlakarKorp/go-cdc-chunkers/tests
cpu: AMD Ryzen Threadripper 3960X 24-Core Processor 
Benchmark_Restic_Rabin_Next
1. Benchmark_Restic_Rabin_Next-48                                	       1	1487764304 ns/op	 721.72 MB/s	      1343 chunks
Benchmark_Askeladdk_FastCDC_Copy
2. Benchmark_Askeladdk_FastCDC_Copy-48                           	       2	 589373428 ns/op	1821.84 MB/s	    105327 chunks
Benchmark_Jotfs_FastCDC_Next
3. Benchmark_Jotfs_FastCDC_Next-48                               	       2	 538782806 ns/op	1992.90 MB/s	      1725 chunks
Benchmark_Tigerwill90_FastCDC_Split
4. Benchmark_Tigerwill90_FastCDC_Split-48                        	       3	 448464996 ns/op	2394.26 MB/s	      2013 chunks
Benchmark_Mhofmann_FastCDC_Next
5. Benchmark_Mhofmann_FastCDC_Next-48                            	       2	 643344838 ns/op	1669.00 MB/s	      1718 chunks
Benchmark_PlakarKorp_FastCDC_Copy
6. Benchmark_PlakarKorp_FastCDC_Copy-48                          	       6	 185143550 ns/op	5799.51 MB/s	      3647 chunks
Benchmark_PlakarKorp_FastCDC_Split
7. Benchmark_PlakarKorp_FastCDC_Split-48                         	       6	 186316712 ns/op	5762.99 MB/s	      3647 chunks
Benchmark_PlakarKorp_FastCDC_Next
8. Benchmark_PlakarKorp_FastCDC_Next-48                          	       6	 186823967 ns/op	5747.35 MB/s	      3647 chunks
Benchmark_PlakarKorp_UltraCDC_Copy
9. Benchmark_PlakarKorp_UltraCDC_Copy-48                         	       6	 167150598 ns/op	6423.80 MB/s	      3955 chunks
Benchmark_PlakarKorp_UltraCDC_Split
10. Benchmark_PlakarKorp_UltraCDC_Split-48                        	       6	 166942244 ns/op	6431.82 MB/s	      3955 chunks
Benchmark_PlakarKorp_UltraCDC_Next
11. Benchmark_PlakarKorp_UltraCDC_Next-48                         	       7	 166595701 ns/op	6445.20 MB/s	      3955 chunks
Benchmark_PlakarKorp_UltraCDC_Batch_Cutpoints
12. Benchmark_PlakarKorp_UltraCDC_Batch_Cutpoints-48              	      19	  56005619 ns/op	19172.04 MB/s	      3955 chunks
Benchmark_PlakarKorp_UltraCDC_Batch_Cutpoints_ReadExtra
13. Benchmark_PlakarKorp_UltraCDC_Batch_Cutpoints_ReadExtra-48    	       9	 121296986 ns/op	8852.17 MB/s	      3955 chunks
Benchmark_PlakarKorp_JC_Copy
14. Benchmark_PlakarKorp_JC_Copy-48                               	       9	 121704776 ns/op	8822.51 MB/s	      4033 chunks
Benchmark_PlakarKorp_JC_Split
15. Benchmark_PlakarKorp_JC_Split-48                              	       9	 121599068 ns/op	8830.18 MB/s	      4033 chunks
Benchmark_PlakarKorp_JC_Next
Benchmark_PlakarKorp_JC_Next-48                               	       9	 121426659 ns/op	8842.72 MB/s	      4033 chunks
PASS
ok  	github.com/PlakarKorp/go-cdc-chunkers/tests	28.932s
~~~